### PR TITLE
Reduce memory alloc

### DIFF
--- a/src/MemoryStore.js
+++ b/src/MemoryStore.js
@@ -9,26 +9,24 @@ class MemoryStore extends Store {
 
     _getHit(key, options) {
         if (!Hits[key]) {
-            const now = new Date();
             Hits[key] = {
                 counter: 0,
-                date_end: now.getTime() + options.interval,
+                date_end: Date.now() + options.interval,
             };
         }
         return Hits[key];
     }
 
     _resetAll() {
-        const now = (new Date()).getTime();
+        const now = Date.now();
         for (const key in Hits) { // eslint-disable-line
             this._resetKey(key, now);
         }
     }
 
     _resetKey(key, now) {
-        now = now || (new Date()).getTime();
-        const elem = Hits[key];
-        if (elem && elem.date_end <= now) {
+        now = now || Date.now();
+        if (Hits[key] && Hits[key].date_end <= now) {
             delete Hits[key];
         }
     }

--- a/src/RateLimit.js
+++ b/src/RateLimit.js
@@ -36,6 +36,7 @@ const Times = {
     month: 2628000000,
     year: 12 * 2628000000,
 };
+const toFinds = ['id', 'userId', 'user_id', 'idUser', 'id_user'];
 
 class RateLimit {
     constructor(options) {
@@ -93,7 +94,6 @@ class RateLimit {
             return this.options.getUserId(ctx);
         }
         const whereFinds = [ctx.state.user, ctx.user, ctx.state.User, ctx.User, ctx.state, ctx];
-        const toFinds = ['id', 'userId', 'user_id', 'idUser', 'id_user'];
         for (const whereFind of whereFinds) {
             if (whereFind) {
                 for (const toFind of toFinds) {


### PR DESCRIPTION
As rate limiter is called on every request, it is better to reduce object allocation as much as we can.
I noticed some minor benefit on garbage collection with my changes, but I can not produce detailed benchmark