### PR TITLE
Fix RedisStore wrong expired seconds

### DIFF
--- a/src/RedisStore.js
+++ b/src/RedisStore.js
@@ -52,7 +52,9 @@ class RedisStore extends Store {
     if(counter === null) {
       counter = weight;
       dateEnd = Date.now() + options.interval;
-      await this.client.setex(key, dateEnd, counter);
+
+      const seconds = Math.ceil(options.interval / 1000);
+      await this.client.setex(key, seconds, counter);
     }else {
       counter = await this.client.incrby(key, weight);
     }


### PR DESCRIPTION
Ref: https://redis.io/commands/setex

seconds parameter should be options.interval / 1000