### PR TITLE
Updating the version of sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "mongoose": "^5.0.7",
     "promise-redis": "0.0.5",
-    "sequelize": "^4.28.1"
+    "sequelize": "^5.3.0"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.3",


### PR DESCRIPTION
Updating to the latest version of sequelize, as there is a security vulnerability in this Sequelize < 5.3.0.

See: https://nvd.nist.gov/vuln/detail/CVE-2019-11069