### PR TITLE
Fix whitelisting uses a different key separator 

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,9 @@ A `ctx.state.rateLimit` property is added to all requests with the `limit`, `cur
 * **statusCode**: HTTP status code returned when `max` is exceeded. Defaults to `429`.
 * **headers**: Enable headers for request limit (`X-RateLimit-Limit`) and current usage (`X-RateLimit-Remaining`) on all responses and time to wait before retrying (`Retry-After`) when `max` is exceeded.
 * **skipFailedRequests**: when `true`, failed requests (response status >= 400) won't be counted. Defaults to `false`.
-* **whitelist**: Array of whitelisted IPs to not be rate limited.
+* **whitelist**: Array of whitelisted IPs/UserIds to not be rate limited.
+* **getUserIdFromKey**: Function that extracts from given key the userId. Defaults to `(key) => key.split(options.prefixKeySeparator)`.
+* **prefixKeySeparator**: Separator string between the prefixKey and the userId. Defaults to `::`. (Set it to `|` if you want whitelist userIds)
 * **getUserId**: Function used to get userId (if connected) to be added as key and saved in bdd, should an abuse case surface. Defaults:
 
     ```js

--- a/src/RateLimit.js
+++ b/src/RateLimit.js
@@ -14,18 +14,21 @@ var defaultOptions = {
     headers: true, // Send custom rate limit header with limit and remaining
     skipFailedRequests: false, // Do not count failed requests (status >= 400)
     prefixKey: 'global', // the prefixKey to get to remove all key
+    prefixKeySeparator: '::', // the seperator between the prefixKey and the userId
+
 
     store: new MemoryStore(),
 
     // redefin fonction
     keyGenerator: undefined,
+    getUserIdFromKey: undefined,
     skip: undefined,
     getUserId: undefined,
     handler: undefined,
     onLimitReached: undefined,
     weight: undefined,
 
-    whitelist: []
+    whitelist: [],
 };
 
 const TimeKeys = ['ms', 'sec', 'min', 'hour', 'day', 'week', 'month', 'year'];
@@ -46,7 +49,6 @@ class RateLimit {
         this.options = Object.assign({}, defaultOptions, options);
         this.options.interval = RateLimit.timeToMs(this.options.interval);
         this.options.timeWait = RateLimit.timeToMs(this.options.timeWait);
-
         // store to use for persisting rate limit data
         this.store = this.options.store;
 
@@ -193,13 +195,26 @@ class RateLimit {
     }
 
     _isWhitelisted(key) {
-        const arr = key.split('|');
-        if (arr.length > 0) {
-            const userId = arr[1];
-            const { whitelist } = this.options;
+        const { whitelist } = this.options;
+
+        if (whitelist == null || whitelist.length === 0) {
+            return false;
+        }
+
+        const userId = this.getUserIdFromKey(key);
+        if (userId) {
             return whitelist.includes(userId);
         }
         return false;
+    }
+
+    getUserIdFromKey(key) {
+        if (this.options.getUserIdFromKey) {
+            return this.options.getUserIdFromKey(key);
+        }
+
+        const [, userId] = key.split(this.options.prefixKeySeparator);
+        return userId;
     }
 
     async wait(ms) {

--- a/src/RateLimit.js
+++ b/src/RateLimit.js
@@ -193,11 +193,11 @@ class RateLimit {
     }
 
     _isWhitelisted(key) {
-        const arr = key.split('::');
+        const arr = key.split('|');
         if (arr.length > 0) {
-            const ip = arr[1];
+            const userId = arr[1];
             const { whitelist } = this.options;
-            return whitelist.includes(ip);
+            return whitelist.includes(userId);
         }
         return false;
     }

--- a/test/RateLimit.js
+++ b/test/RateLimit.js
@@ -276,4 +276,16 @@ describe('RateLimit node module', () => {
         expect(dateEndReset).toBe(dateEndSec);
         expect(ctx.state.rateLimit.reset).toBe(dateEndSec);
     });
+
+    it('should skip ratelimit if userId is whitelisted', async () => {
+        store.incr = async () => {
+            assert.fail('Ratelimit wasn\'t skipped');
+        };
+
+        ctx.state.user.id = 'userId';
+        const middleware = RateLimit.middleware({ store, whitelist: ['userId'] });
+        await middleware(ctx, nextNb);
+        
+        expect(nbCall).toBe(1);
+    });
 });


### PR DESCRIPTION
For me the whitelisting feature wasn't working since it uses a different key separator to split the key into prefix and userId.  

The default _keyGenerator_ uses a  '|' to separate the prefix from the userId
but __isWhitelisted_ used '::' to split the key into prefix and userId.


