### PR TITLE
Make peerDependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,17 @@
     "redis": ">= 4.0.0",
     "sequelize": ">=5.8.7"
   },
+  "peerDependenciesMeta": {
+    "mongoose": {
+      "optional": true
+    },
+    "redis": {
+      "optional": true
+    },
+    "sequelize": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "babel-eslint": "^10.0.1",
     "eslint": "^5.16.0",


### PR DESCRIPTION
Following the discussion in https://github.com/ysocorp/koa2-ratelimit/issues/47.

- This PR make peerDependencies optional  to avoid unnecessary npm warnings.
